### PR TITLE
Fix docker cmd to mount configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,8 +219,8 @@ ssh-key: |
 
 ```bash
 docker run --restart=on-failure \
+  -v "$(pwd)":/configuration \
   smarkets/marge-bot \
-  -v "$(pwd)":/configuration
   --config-file=/configuration/marge-bot-config.yaml
 ```
 


### PR DESCRIPTION
With the current command, I have the following error : 
```
$ docker run smarkets/marge-bot -v $(pwd):/configuration --config-file=/configuration/marge-bot-config.yaml
usage: marge.app [-h] [--config-file CONFIG_FILE]
                 (--auth-token TOKEN | --auth-token-file FILE) --gitlab-url
                 URL (--ssh-key KEY | --ssh-key-file FILE)
                 [--embargo INTERVAL[,..]] [--use-merge-strategy]
                 [--add-tested] [--batch] [--add-part-of] [--add-reviewers]
                 [--impersonate-approvers]
                 [--approval-reset-timeout APPROVAL_RESET_TIMEOUT]
                 [--project-regexp PROJECT_REGEXP] [--ci-timeout CI_TIMEOUT]
                 [--max-ci-time-in-minutes MAX_CI_TIME_IN_MINUTES]
                 [--git-timeout GIT_TIMEOUT] [--branch-regexp BRANCH_REGEXP]
                 [--debug]
marge.app: error: File not found: /configuration/marge-bot-config.yaml
```